### PR TITLE
Add fast path for regular case

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -24,12 +24,12 @@ check_dots_used <- function(env = parent.frame()) {
 }
 
 check_dots <- function(env = parent.frame()) {
-  proms <- dots(env)
-  used <- vapply(proms, promise_forced, logical(1))
-
-  if (all(used)) {
+  if (.Call(ellipsis_dots_used, env)) {
     return(invisible())
   }
+
+  proms <- dots(env)
+  used <- vapply(proms, promise_forced, logical(1))
 
   unnused <- names(proms)[!used]
   warning(

--- a/src/dots.c
+++ b/src/dots.c
@@ -70,6 +70,29 @@ SEXP ellipsis_promise_forced(SEXP x) {
   return Rf_ScalarLogical(promise_forced(x));
 }
 
+SEXP ellipsis_dots_used(SEXP env) {
+  SEXP dots = PROTECT(find_dots(env));
+
+  if (dots == R_MissingArg) {
+    UNPROTECT(1);
+    return Rf_ScalarLogical(true);
+  }
+
+  while (dots != R_NilValue) {
+    SEXP elt = CAR(dots);
+
+    if (!promise_forced(elt)) {
+      UNPROTECT(1);
+      return Rf_ScalarLogical(false);
+    }
+
+    dots = CDR(dots);
+  }
+
+  UNPROTECT(1);
+  return Rf_ScalarLogical(true);
+}
+
 SEXP ellipsis_eval_bare(SEXP expr, SEXP env) {
   return Rf_eval(expr, env);
 }

--- a/src/dots.c
+++ b/src/dots.c
@@ -3,6 +3,7 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 static SEXP find_dots(SEXP env) {
   if (TYPEOF(env) != ENVSXP) {
@@ -58,12 +59,15 @@ SEXP ellipsis_dots(SEXP env, SEXP auto_name_) {
   return out;
 }
 
+static bool promise_forced(SEXP x) {
+  if (TYPEOF(x) != PROMSXP) {
+    return true;
+  } else {
+    return PRVALUE(x) != R_UnboundValue;
+  }
+}
 SEXP ellipsis_promise_forced(SEXP x) {
-  if (TYPEOF(x) != PROMSXP)
-    return Rf_ScalarLogical(TRUE);
-
-  SEXP value = PRVALUE(x);
-  return Rf_ScalarLogical(value != R_UnboundValue);
+  return Rf_ScalarLogical(promise_forced(x));
 }
 
 SEXP ellipsis_eval_bare(SEXP expr, SEXP env) {

--- a/src/init.c
+++ b/src/init.c
@@ -7,11 +7,13 @@
 extern SEXP ellipsis_promise_forced(SEXP);
 extern SEXP ellipsis_dots(SEXP, SEXP);
 extern SEXP ellipsis_eval_bare(SEXP, SEXP);
+extern SEXP ellipsis_dots_used(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"ellipsis_dots", (DL_FUNC) &ellipsis_dots, 2},
     {"ellipsis_promise_forced", (DL_FUNC) &ellipsis_promise_forced, 1},
     {"ellipsis_eval_bare", (DL_FUNC) &ellipsis_eval_bare, 2},
+    {"ellipsis_dots_used", (DL_FUNC) &ellipsis_dots_used, 1},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Includes #13 

This brings performance closer to regular function calls:

```
## Laptop:

  expression     min    mean  median    max `itr/sec` mem_alloc  n_gc n_itr
  <chr>      <bch:t> <bch:t> <bch:t> <bch:>     <dbl> <bch:byt> <dbl> <int>
1 a_nodispa…  1.48µs  2.35µs  1.83µs 1.99ms   426064.        0B     2  9998
2 b_dispatch  2.98µs  3.83µs   3.5µs 1.17ms   260862.    3.77MB     2  9998
3 c_before    14.9µs 19.06µs 17.25µs 2.11ms    52468.   42.26KB     8  9992
4 d_after     6.04µs  8.59µs  7.16µs 1.57ms   116373.   28.38KB     4  9996
# … with 5 more variables: total_time <bch:tm>, result <list>,
#   memory <list>, time <list>, gc <list>
```