### PR TITLE
Remove space after "R (>= 3.2)"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ RoxygenNote: 6.1.1
 URL: https://ellipsis.r-lib.org, https://github.com/r-lib/ellipsis
 BugReports: https://github.com/r-lib/ellipsis/issues
 Depends: 
-    R (>= 3.2)  
+    R (>= 3.2)
 Imports:
     rlang (>= 0.3.0)
 Suggests: 


### PR DESCRIPTION
This appears to be causing breaks when trying to install downstream packages:

``` r
devtools::install_github("r-lib/ellipsis")
#> Downloading GitHub repo r-lib/ellipsis@master
#> Error in FUN(X[[i]], ...): Invalid comparison operator in dependency: >=

devtools::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.1 (2019-07-05)
#>  os       macOS Mojave 10.14.6        
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       America/Chicago             
#>  date     2019-09-07                  
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  package     * version    date       lib source                      
#>  assertthat    0.2.1      2019-03-21 [1] CRAN (R 3.6.0)              
#>  backports     1.1.4      2019-04-10 [1] CRAN (R 3.6.0)              
#>  callr         3.2.0      2019-03-15 [1] CRAN (R 3.6.0)              
#>  cli           1.1.0      2019-03-19 [1] CRAN (R 3.6.0)              
#>  crayon        1.3.4      2017-09-16 [1] CRAN (R 3.6.0)              
#>  curl          4.0        2019-07-22 [1] CRAN (R 3.6.0)              
#>  desc          1.2.0      2018-05-01 [1] CRAN (R 3.6.0)              
#>  devtools      2.0.2      2019-04-08 [1] CRAN (R 3.6.0)              
#>  digest        0.6.20     2019-07-04 [1] CRAN (R 3.6.0)              
#>  evaluate      0.14       2019-05-28 [1] CRAN (R 3.6.0)              
#>  fs            1.3.1      2019-05-06 [1] CRAN (R 3.6.0)              
#>  glue          1.3.1      2019-03-12 [1] CRAN (R 3.6.0)              
#>  highr         0.8        2019-03-20 [1] CRAN (R 3.6.0)              
#>  htmltools     0.3.6      2017-04-28 [1] CRAN (R 3.6.0)              
#>  knitr         1.24       2019-08-08 [1] CRAN (R 3.6.0)              
#>  magrittr      1.5        2014-11-22 [1] CRAN (R 3.6.0)              
#>  memoise       1.1.0      2017-04-21 [1] CRAN (R 3.6.0)              
#>  pkgbuild      1.0.3      2019-03-20 [1] CRAN (R 3.6.0)              
#>  pkgload       1.0.2      2018-10-29 [1] CRAN (R 3.6.0)              
#>  prettyunits   1.0.2      2015-07-13 [1] CRAN (R 3.6.0)              
#>  processx      3.4.0      2019-07-03 [1] CRAN (R 3.6.0)              
#>  ps            1.3.0      2018-12-21 [1] CRAN (R 3.6.0)              
#>  R6            2.4.0      2019-02-14 [1] CRAN (R 3.6.0)              
#>  Rcpp          1.0.2      2019-07-25 [1] CRAN (R 3.6.0)              
#>  remotes       2.0.4      2019-04-10 [1] CRAN (R 3.6.0)              
#>  rlang         0.4.0.9002 2019-08-29 [1] Github (r-lib/rlang@15e799c)
#>  rmarkdown     1.15       2019-08-21 [1] CRAN (R 3.6.0)              
#>  rprojroot     1.3-2      2018-01-03 [1] CRAN (R 3.6.0)              
#>  sessioninfo   1.1.1      2018-11-05 [1] CRAN (R 3.6.0)              
#>  stringi       1.4.3      2019-03-12 [1] CRAN (R 3.6.0)              
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 3.6.0)              
#>  testthat      2.1.1      2019-04-23 [1] CRAN (R 3.6.0)              
#>  usethis       1.5.1      2019-07-04 [1] CRAN (R 3.6.0)              
#>  withr         2.1.2      2018-03-15 [1] CRAN (R 3.6.0)              
#>  xfun          0.9        2019-08-21 [1] CRAN (R 3.6.0)              
#>  yaml          2.2.0      2018-07-25 [1] CRAN (R 3.6.0)              
#> 
#> [1] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
```

<sup>Created on 2019-09-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
