### PR TITLE
Allow specifying an action for the checks functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ellipsis (development version)
 
+* `check_dots_used()`, `check_dots_unnamed()`, and `check_dots_empty()` gain an
+  `action` argument, to specify if they should error, warn, message or signal
+  when the dots meet the condition.
 
 # ellipsis 0.2.0
 

--- a/man/check_dots_empty.Rd
+++ b/man/check_dots_empty.Rd
@@ -4,10 +4,13 @@
 \alias{check_dots_empty}
 \title{Check that dots are unused}
 \usage{
-check_dots_empty(env = parent.frame())
+check_dots_empty(env = parent.frame(), action = abort)
 }
 \arguments{
 \item{env}{Environment in which to look for \code{...}.}
+
+\item{action}{The action to take when the dots have not been used. One of
+\code{\link[rlang:abort]{rlang::abort()}}, \code{\link[rlang:warn]{rlang::warn()}}, \code{\link[rlang:inform]{rlang::inform()}} or \code{\link[rlang:signal]{rlang::signal()}}.}
 }
 \description{
 Sometimes you just want to use \code{...} to force your users to fully name

--- a/man/check_dots_unnamed.Rd
+++ b/man/check_dots_unnamed.Rd
@@ -4,10 +4,13 @@
 \alias{check_dots_unnamed}
 \title{Check that all dots are unnamed}
 \usage{
-check_dots_unnamed(env = parent.frame())
+check_dots_unnamed(env = parent.frame(), action = abort)
 }
 \arguments{
 \item{env}{Environment in which to look for \code{...}.}
+
+\item{action}{The action to take when the dots have not been used. One of
+\code{\link[rlang:abort]{rlang::abort()}}, \code{\link[rlang:warn]{rlang::warn()}}, \code{\link[rlang:inform]{rlang::inform()}} or \code{\link[rlang:signal]{rlang::signal()}}.}
 }
 \description{
 Named arguments in ... are often a sign of misspelled argument names.

--- a/man/check_dots_used.Rd
+++ b/man/check_dots_used.Rd
@@ -4,10 +4,13 @@
 \alias{check_dots_used}
 \title{Check that all dots have been used}
 \usage{
-check_dots_used(env = parent.frame())
+check_dots_used(env = parent.frame(), action = abort)
 }
 \arguments{
 \item{env}{Environment in which to look for \code{...} and to set up handler.}
+
+\item{action}{The action to take when the dots have not been used. One of
+\code{\link[rlang:abort]{rlang::abort()}}, \code{\link[rlang:warn]{rlang::warn()}}, \code{\link[rlang:inform]{rlang::inform()}} or \code{\link[rlang:signal]{rlang::signal()}}.}
 }
 \description{
 Automatically sets exit handler to run when function terminates, checking

--- a/man/ellipsis-package.Rd
+++ b/man/ellipsis-package.Rd
@@ -6,7 +6,7 @@
 \alias{ellipsis-package}
 \title{ellipsis: Tools for Working with ...}
 \description{
-... is a powerful tool for function extensibility. Unfortunately 
+The ellipsis is a powerful tool for extending functions. Unfortunately 
     this power comes at a cost: misspelled arguments will be silently ignored. 
     The ellipsis package provides a collection of functions to catch problems
     and alert the user.
@@ -14,6 +14,7 @@
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://ellipsis.r-lib.org}
   \item \url{https://github.com/r-lib/ellipsis}
   \item Report bugs at \url{https://github.com/r-lib/ellipsis/issues}
 }

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -7,7 +7,7 @@ test_that("error if dots not used", {
   }
 
   expect_error(f(1, 2), NA)
-  expect_error(f(1, 2, 3), class = "rlib_error_dots_unnused")
+  expect_error(f(1, 2, 3), class = "rlib_error_dots_unused")
 })
 
 test_that("error if dots not used by another function", {
@@ -20,7 +20,7 @@ test_that("error if dots not used by another function", {
   }
 
   expect_error(f(x = 10, a = 1), NA)
-  expect_error(f(x = 10, c = 3), class = "rlib_error_dots_unnused")
+  expect_error(f(x = 10, c = 3), class = "rlib_error_dots_unused")
 })
 
 test_that("error if dots named", {
@@ -41,4 +41,22 @@ test_that("error if if dots not empty", {
 
   expect_error(f(xyz = 1), NA)
   expect_error(f(xy = 4), class = "rlib_error_dots_nonempty")
+})
+
+test_that("can control the action", {
+  f <- function(action, check, ..., xyz = 1) {
+    check(action = action)
+  }
+
+  expect_error(f(abort, check_dots_used, xy = 4), class = "rlib_error_dots_unused")
+  expect_warning(f(warn, check_dots_used, xy = 4), class = "rlib_error_dots_unused")
+  expect_message(f(inform, check_dots_used, xy = 4), class = "rlib_error_dots_unused")
+
+  expect_error(f(abort, check_dots_unnamed, xy = 4), class = "rlib_error_dots_named")
+  expect_warning(f(warn, check_dots_unnamed, xy = 4), class = "rlib_error_dots_named")
+  expect_message(f(inform, check_dots_unnamed, xy = 4), class = "rlib_error_dots_named")
+
+  expect_error(f(abort, check_dots_empty, xy = 4), class = "rlib_error_dots_nonempty")
+  expect_warning(f(warn, check_dots_empty, xy = 4), class = "rlib_error_dots_nonempty")
+  expect_message(f(inform, check_dots_empty, xy = 4), class = "rlib_error_dots_nonempty")
 })

--- a/tests/testthat/test-safe.R
+++ b/tests/testthat/test-safe.R
@@ -3,5 +3,5 @@ context("test-safe")
 test_that("warn if unused dots", {
   expect_error(safe_median(1:10), NA)
   expect_error(safe_median(1:10, na.rm = TRUE), NA)
-  expect_error(safe_median(1:10, y = 1), class = "rlib_error_dots_unnused")
+  expect_error(safe_median(1:10, y = 1), class = "rlib_error_dots_unused")
 })


### PR DESCRIPTION
This gives the package developer more flexibility in what happens when
one of the check functions is used. Rather than always being an error
they can now have ellipsis issue a warning, message or signal.